### PR TITLE
fix: add ingress path for js snippet

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -45,5 +45,12 @@ spec:
                 name: {{ include "jitsu.fullname" . }}-ingest
                 port:
                   number: {{ .Values.ingest.service.port }}
+          - path: /p.js
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "jitsu.fullname" . }}-ingest
+                port:
+                  number: {{ .Values.ingest.service.port }}
           {{- end }}
 {{- end }}


### PR DESCRIPTION
This should resolve #7.

It looks like p.js is handled by ingest, not by the console.

https://github.com/jitsucom/bulker/blob/08893e95ede789d1fa820f3c21d707cd1b71bd6c/ingest/router.go#L79