### PR TITLE
fix: add startup probe to rotor

### DIFF
--- a/templates/rotor/deployment.yaml
+++ b/templates/rotor/deployment.yaml
@@ -112,6 +112,11 @@ spec:
             httpGet:
               port: http
               path: /health
+          startupProbe:
+            httpGet:
+              port: http
+              path: /health
+            failureThreshold: 60
           {{- end }}
           {{- if .Values.rotor.envFrom }}
           envFrom:


### PR DESCRIPTION
gives the rotor 10 min to start, as it can be a little slow while kafka is getting ready