### PR TITLE
Fix clickhouse ports and passwords in helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,10 @@ This release disables the Redis deployment by default as it is no longer require
 If you have functions persistent storage or identity stitching data you wish to keep, set
 `redis.enabled` to `true` to enable "double read" mode as outlined in the [release notes for Jitsu
 v2.5.0](https://github.com/jitsucom/jitsu/releases/tag/jitsu2-v2.5.0).
+
+### TODO: TBD
+This release splits the `config.clickhouseHost` and `config.clickhouseHostFrom` parameters up into
+separate parameters for HTTP and TCP, as different components require different protocols. If you
+were using these parameters, simply set `config.clickhouseHttpHost` and `config.clickhouseTcpHost`
+(or the equivalent `...From` variants) making sure to set the correct port. If you were setting this
+on a per-component basis or letting the chart configure it for you no action is needed.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -118,11 +118,19 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "jitsu.clickhouseHost" -}}
-{{- if and (not .Values.config.clickhouseHost) .Values.clickhouse.enabled -}}
+{{- define "jitsu.clickhouseHttpHost" -}}
+{{- if and (not .Values.config.clickhouseHttpHost) .Values.clickhouse.enabled -}}
+{{ .Release.Name }}-clickhouse:8123
+{{- else -}}
+{{ .Values.config.clickhouseHttpHost }}
+{{- end }}
+{{- end }}
+
+{{- define "jitsu.clickhouseTcpHost" -}}
+{{- if and (not .Values.config.clickhouseTcpHost) .Values.clickhouse.enabled -}}
 {{ .Release.Name }}-clickhouse:9000
 {{- else -}}
-{{ .Values.config.clickhouseHost }}
+{{ .Values.config.clickhouseTcpHost }}
 {{- end }}
 {{- end }}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -119,33 +119,33 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "jitsu.clickhouseHost" -}}
-{{- if and (not .Values.config.clickhouseHost) .Values.clickhouse.enabled }}
-{{ .Release.Name }}-clickhouse:8123
-{{- else }}
+{{- if and (not .Values.config.clickhouseHost) .Values.clickhouse.enabled -}}
+{{ .Release.Name }}-clickhouse:9000
+{{- else -}}
 {{ .Values.config.clickhouseHost }}
 {{- end }}
 {{- end }}
 
 {{- define "jitsu.clickhouseDatabase" -}}
-{{- if and (not .Values.config.clickhouseDatabase) .Values.clickhouse.enabled }}
+{{- if and (not .Values.config.clickhouseDatabase) .Values.clickhouse.enabled -}}
 default
-{{- else }}
+{{- else -}}
 {{ .Values.config.clickhouseDatabase }}
 {{- end }}
 {{- end }}
 
 {{- define "jitsu.clickhouseUsername" -}}
-{{- if and (not .Values.config.clickhouseUsername) .Values.clickhouse.enabled }}
+{{- if and (not .Values.config.clickhouseUsername) .Values.clickhouse.enabled -}}
 jitsu
-{{- else }}
+{{- else -}}
 {{ .Values.config.clickhouseUsername }}
 {{- end }}
 {{- end }}
 
 {{- define "jitsu.clickhousePassword" -}}
-{{- if and (not .Values.config.clickhousePassword) .Values.clickhouse.enabled }}
+{{- if and (not .Values.config.clickhousePassword) .Values.clickhouse.enabled -}}
 jitsu
-{{- else }}
+{{- else -}}
 {{ .Values.config.clickhousePassword }}
 {{- end }}
 {{- end }}

--- a/templates/bulker/_helpers.tpl
+++ b/templates/bulker/_helpers.tpl
@@ -167,13 +167,13 @@ app.kubernetes.io/component: bulker
 {{- end }}
 {{- end }}
 
-{{- if or .clickhouseHostFrom $.Values.config.clickhouseHostFrom }}
+{{- if or .clickhouseHostFrom $.Values.config.clickhouseTcpHostFrom }}
 - name: BULKER_CLICKHOUSE_HOST
   valueFrom:
-    {{- toYaml (.clickhouseHostFrom | default $.Values.config.clickhouseHostFrom) | nindent 4 }}
+    {{- toYaml (.clickhouseHostFrom | default $.Values.config.clickhouseTcpHostFrom) | nindent 4 }}
 {{- else }}
 - name: BULKER_CLICKHOUSE_HOST
-  value: {{ .clickhouseHost | default (include "jitsu.clickhouseHost" $) | quote }}
+  value: {{ .clickhouseHost | default (include "jitsu.clickhouseTcpHost" $) | quote }}
 {{- end }}
 
 {{- if or .clickhouseDatabaseFrom $.Values.config.clickhouseDatabaseFrom }}

--- a/templates/console/_helpers.tpl
+++ b/templates/console/_helpers.tpl
@@ -31,7 +31,7 @@ app.kubernetes.io/component: console
     {{- toYaml (.clickhouseHostFrom | default $.Values.config.clickhouseHostFrom) | nindent 4 }}
 {{- else }}
 - name: CLICKHOUSE_HOST
-  value: {{ .clickhouseHost | default (include "jitsu.clickhouseHost" $) | quote }}
+  value: {{ .clickhouseHost | default ((include "jitsu.clickhouseHost" $) | replace "9000" "8123") | quote }}
 {{- end }}
 
 {{- if or .clickhouseDatabaseFrom $.Values.config.clickhouseDatabaseFrom }}

--- a/templates/console/_helpers.tpl
+++ b/templates/console/_helpers.tpl
@@ -25,13 +25,13 @@ app.kubernetes.io/component: console
   value: {{ .databaseUrl | default (include "jitsu.databaseUrl" $) | quote }}
 {{- end }}
 
-{{- if or .clickhouseHostFrom $.Values.config.clickhouseHostFrom }}
+{{- if or .clickhouseHostFrom $.Values.config.clickhouseHttpHostFrom }}
 - name: CLICKHOUSE_HOST
   valueFrom:
-    {{- toYaml (.clickhouseHostFrom | default $.Values.config.clickhouseHostFrom) | nindent 4 }}
+    {{- toYaml (.clickhouseHostFrom | default $.Values.config.clickhouseHttpHostFrom) | nindent 4 }}
 {{- else }}
 - name: CLICKHOUSE_HOST
-  value: {{ .clickhouseHost | default ((include "jitsu.clickhouseHost" $) | replace "9000" "8123") | quote }}
+  value: {{ .clickhouseHost | default (include "jitsu.clickhouseHttpHost" $) | quote }}
 {{- end }}
 
 {{- if or .clickhouseDatabaseFrom $.Values.config.clickhouseDatabaseFrom }}

--- a/templates/ingest/_helpers.tpl
+++ b/templates/ingest/_helpers.tpl
@@ -19,13 +19,13 @@ app.kubernetes.io/component: ingest
   value: {{ .redisUrl | default (include "jitsu.redisUrl" $) | quote }}
 {{- end }}
 
-{{- if or .clickhouseHostFrom $.Values.config.clickhouseHostFrom }}
+{{- if or .clickhouseHostFrom $.Values.config.clickhouseTcpHostFrom }}
 - name: INGEST_CLICKHOUSE_HOST
   valueFrom:
-    {{- toYaml (.clickhouseHostFrom | default $.Values.config.clickhouseHostFrom) | nindent 4 }}
+    {{- toYaml (.clickhouseHostFrom | default $.Values.config.clickhouseTcpHostFrom) | nindent 4 }}
 {{- else }}
 - name: INGEST_CLICKHOUSE_HOST
-  value: {{ .clickhouseHost | default (include "jitsu.clickhouseHost" $) | quote }}
+  value: {{ .clickhouseHost | default (include "jitsu.clickhouseTcpHost" $) | quote }}
 {{- end }}
 
 {{- if or .clickhouseDatabaseFrom $.Values.config.clickhouseDatabaseFrom }}

--- a/templates/rotor/_helpers.tpl
+++ b/templates/rotor/_helpers.tpl
@@ -25,13 +25,13 @@ app.kubernetes.io/component: rotor
   value: {{ .mongodbUrl | default (include "jitsu.mongodbUrl" $) | quote }}
 {{- end }}
 
-{{- if or .clickhouseHostFrom $.Values.config.clickhouseHostFrom }}
+{{- if or .clickhouseHostFrom $.Values.config.clickhouseHttpHostFrom }}
 - name: CLICKHOUSE_HOST
   valueFrom:
-    {{- toYaml (.clickhouseHostFrom | default $.Values.config.clickhouseHostFrom) | nindent 4 }}
+    {{- toYaml (.clickhouseHostFrom | default $.Values.config.clickhouseHttpHostFrom) | nindent 4 }}
 {{- else }}
 - name: CLICKHOUSE_HOST
-  value: {{ .clickhouseHost | default ((include "jitsu.clickhouseHost" $) | replace "9000" "8123") | quote }}
+  value: {{ .clickhouseHost | default (include "jitsu.clickhouseHttpHost" $) | quote }}
 {{- end }}
 
 {{- if or .clickhouseDatabaseFrom $.Values.config.clickhouseDatabaseFrom }}

--- a/templates/rotor/_helpers.tpl
+++ b/templates/rotor/_helpers.tpl
@@ -31,7 +31,7 @@ app.kubernetes.io/component: rotor
     {{- toYaml (.clickhouseHostFrom | default $.Values.config.clickhouseHostFrom) | nindent 4 }}
 {{- else }}
 - name: CLICKHOUSE_HOST
-  value: {{ .clickhouseHost | default (include "jitsu.clickhouseHost" $) | quote }}
+  value: {{ .clickhouseHost | default ((include "jitsu.clickhouseHost" $) | replace "9000" "8123") | quote }}
 {{- end }}
 
 {{- if or .clickhouseDatabaseFrom $.Values.config.clickhouseDatabaseFrom }}

--- a/values.yaml
+++ b/values.yaml
@@ -32,8 +32,11 @@ config:
 
   # Global Clickhouse configuration.
   # Will be configured automatically if left empty and using the Clickhouse subchart.
-  clickhouseHost: ""
-  clickhouseHostFrom: {}
+  # HTTP/TCP endpoints are separate as different components require the use of different protocols.
+  clickhouseHttpHost: ""
+  clickhouseHttpHostFrom: {}
+  clickhouseTcpHost: ""
+  clickhouseTcpHostFrom: {}
   clickhouseDatabase: ""
   clickhouseDatabaseFrom: {}
   clickhouseUsername: ""


### PR DESCRIPTION
* Clickhouse needs port 8123 (HTTP) for console and rotor, but needs port 9000 (TCP) for bulker and ingest.  See the
[docker-compose.yaml](https://github.com/jitsucom/jitsu/blob/newjitsu/docker/docker-compose.yml).

* Clean up newlines that were creating username and passwords like "\njitsu".

I am not sure this is the cleanest way to handle the port issue.  Another option would be to break out the clickhouse port and have differing defaults by service.