### PR TITLE
Fix the usage of custom envs in the rotor template

### DIFF
--- a/templates/rotor/deployment.yaml
+++ b/templates/rotor/deployment.yaml
@@ -140,7 +140,7 @@ spec:
             {{- include "jitsu.rotor.env" . | nindent 12 }}
             {{- end }}
             {{- with .Values.rotor.env }}
-            {{- toYaml .Values.rotor.env | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with (.Values.rotor.resources | default .Values.global.resources) }}
           resources:


### PR DESCRIPTION
## Motivation
The current version of the rotor template gives me the following error when I try to use custom envs in `rotor`:
```
Error:  templates/: template: .../rotor/deployment.yaml:143:30: executing ".../rotor/deployment.yaml" at <.Values.rotor.env>: nil pointer evaluating interface {}.rotor
```

## Solution
Since the `toYaml` call is inside a `with` block we don't need to repeat the full variable path again.