### PR TITLE
fix: use ReleaseName in rotor wait-for-kafka

### DIFF
--- a/templates/rotor/deployment.yaml
+++ b/templates/rotor/deployment.yaml
@@ -72,7 +72,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           image: ghcr.io/groundnuty/k8s-wait-for:v2.0
-          args: ["service", "{{ include "jitsu.fullname" . }}-kafka"]
+          args: ["service", "{{ .Release.Name }}-kafka"]
         {{- end }}
         {{- if .Values.mongodb.enabled }}
         - name: wait-for-mongodb


### PR DESCRIPTION
Fix Rotor's `wait-for-kafka` cmd so that it waits for a Service that actually exist and doesn't hang forever.