### PR TITLE
Fix: Incorrect environment variables injected when tokenGenerator is disabled

### DIFF
--- a/templates/event-log-init/job.yaml
+++ b/templates/event-log-init/job.yaml
@@ -87,7 +87,7 @@ spec:
             {{- end }}
             {{- with .Values.eventLogInit.config.consoleAuthToken }}
             - name: CONSOLE_AUTH_TOKEN
-              value: {{ .Values.eventLogInit.config.consoleAuthToken | quote }}
+              value: {{ . | quote }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/templates/event-log-trim/cronjob.yaml
+++ b/templates/event-log-trim/cronjob.yaml
@@ -90,7 +90,7 @@ spec:
                 {{- end }}
                 {{- with .Values.eventLogTrim.config.consoleAuthToken }}
                 - name: CONSOLE_AUTH_TOKEN
-                  value: {{ .Values.eventLogTrim.config.consoleAuthToken | quote }}
+                  value: {{ . | quote }}
                 {{- end }}
                 {{- end }}
                 {{- end }}

--- a/templates/ingest/_helpers.tpl
+++ b/templates/ingest/_helpers.tpl
@@ -120,7 +120,7 @@ app.kubernetes.io/component: ingest
       key: globalHashSecret
 {{- end }}
 {{- with (.globalHashSecret | default $.Values.config.globalHashSecret) }}
-- name: GLOBAL_HASH_SECRET
+- name: INGEST_GLOBAL_HASH_SECRET
   value: {{ . | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR addresses issues with environment variables injected into certain resources when the `tokenGenerator` is disabled and the configs `consoleAuthToken` and `globalHashSecret` are set.

Specifically, this PR:
- Corrects the `CONSOLE_AUTH_TOKEN` env in the `event-log-init` and `event-log-trim`. The current template cannot be applied because the `.Values` variable does not exist inside the `with` block.
- Fixes the name of the `globalHashSecret` injected into the ingest deployment. It should have the `INGEST_` prefix.