### PR TITLE
Add startup probe for bulker

### DIFF
--- a/templates/bulker/deployment.yaml
+++ b/templates/bulker/deployment.yaml
@@ -112,6 +112,11 @@ spec:
             httpGet:
               port: http
               path: /ready
+          startupProbe:
+            httpGet:
+              port: http
+              path: /health
+            failureThreshold: 60
           {{- end }}
           {{- if .Values.bulker.envFrom }}
           envFrom:


### PR DESCRIPTION
Fix for bulker crash loop on startup under heavy kafka load.