### PR TITLE
chore(deps): upgrade to latest before bitnami pulls the plug

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 15.5.38
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.2.0
+  version: 20.13.4
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 30.1.5
+  version: 30.1.8
 - name: mongodb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.0.3
+  version: 16.5.45
 - name: clickhouse
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 6.2.27
-digest: sha256:edeea0d4376d049530cd041224b2ceee14a60ae0051b5d5ebf5a23e98d2de452
-generated: "2024-10-11T12:17:19.12668398+02:00"
+  version: 6.3.3
+digest: sha256:021d670342ca73d1330f455296fea661f8e186bcf33657aaf0fc4b5f5c2d32ae
+generated: "2025-08-27T15:59:10.350434542+02:00"


### PR DESCRIPTION
Fixes #77 