### PR TITLE
fix(wait-for): use string comparison to "true" to evaluate initcontainer conditions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,14 +2,14 @@
 charset = utf-8
 end_of_line = lf
 indent_style = space
-indent_size=2
+indent_size = 2
 insert_final_newline = true
 max_line_length = 100
 trim_trailing_whitespace = true
 
 [*.py]
-indent_style=space
-indent_size=4
+indent_style = space
+indent_size = 4
 
 [*.nix]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,15 @@
 [*]
-indent_style=space
+charset = utf-8
+end_of_line = lf
+indent_style = space
 indent_size=2
+insert_final_newline = true
+max_line_length = 100
+trim_trailing_whitespace = true
 
 [*.py]
 indent_style=space
 indent_size=4
+
+[*.nix]
+indent_size = 2

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /charts
+result
+.direnv
+.env

--- a/.helmignore
+++ b/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+.direnv/
+result
+.env

--- a/.helmignore
+++ b/.helmignore
@@ -21,6 +21,11 @@
 .idea/
 *.tmproj
 .vscode/
-.direnv/
+# Nix build result
 result
-.env
+# Direnv cache
+.direnv/
+# Tracked files that aren't useful outside of development
+flake.nix
+flake.lock
+.editorconfig

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1763421233,
+        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      lib = nixpkgs.lib;
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      argsFor = system: {
+        pkgs = nixpkgs.legacyPackages.${system};
+      };
+      forAllSystems = f: lib.genAttrs systems (system: f (argsFor system));
+    in
+    {
+      devShells = forAllSystems (
+        { pkgs, ... }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              kubernetes-helm
+            ];
+          };
+        }
+      );
+
+      formatter = forAllSystems (
+        { pkgs, ... }:
+        pkgs.treefmt.withConfig {
+          settings = {
+            on-unmatched = "info";
+            formatter.nixfmt = {
+              command = lib.getExe pkgs.nixfmt-rfc-style;
+              includes = [ "*.nix" ];
+            };
+          };
+        }
+      );
+    };
+}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -176,7 +176,7 @@ jitsu
   image: {{ include "jitsu.waitFor.image" $global}}
   {{- with ($component.securityContext | default $global.Values.global.securityContext) }}
   securityContext:
-    {{- toYaml . | nindent 12 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   command: ["kubectl", "wait"]
   args:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -173,7 +173,7 @@ jitsu
 {{- range . }}
 {{- if eq "true" (tpl (.enabled | default "true") $global) }}
 - name: {{ printf "wait-for-%s" .name | quote }}
-  image: {{ include "jitsu.waitFor.image" $global}}
+  image: {{ include "jitsu.waitFor.image" $global }}
   {{- with ($component.securityContext | default $global.Values.global.securityContext) }}
   securityContext:
     {{- toYaml . | nindent 4 }}

--- a/templates/bulker/deployment.yaml
+++ b/templates/bulker/deployment.yaml
@@ -38,23 +38,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- with .Values.bulker.waitFor }}
-        {{- range . }}
-        {{- if (fromYaml (tpl (.enabled | default "true") $ )) }}
-        - name: {{ printf "wait-for-%s" .name | quote }}
-          image: {{ include "jitsu.waitFor.image" $ }}
-          {{- with ($.Values.bulker.securityContext | default $.Values.global.securityContext) }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          command: ["kubectl", "wait"]
-          args:
-            - {{ tpl .for $ | printf "--for=%s" | quote }}
-            - {{ default "300s" .timeout | printf "--timeout=%s" | quote }}
-            - {{ tpl .resource $ | quote }}
-        {{- end }}
-        {{- end }}
-        {{- end }}
+        {{- include "jitsu.waitFor.initContainers" (list $ .Values.bulker) | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with (.Values.bulker.securityContext | default .Values.global.securityContext) }}

--- a/templates/console/deployment.yaml
+++ b/templates/console/deployment.yaml
@@ -38,23 +38,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- with .Values.console.waitFor }}
-        {{- range . }}
-        {{- if (fromYaml (tpl (.enabled | default "true") $ )) }}
-        - name: {{ printf "wait-for-%s" .name | quote }}
-          image: {{ include "jitsu.waitFor.image" $ }}
-          {{- with ($.Values.console.securityContext | default $.Values.global.securityContext) }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          command: ["kubectl", "wait"]
-          args:
-            - {{ tpl .for $ | printf "--for=%s" | quote }}
-            - {{ default "300s" .timeout | printf "--timeout=%s" | quote }}
-            - {{ tpl .resource $ | quote }}
-        {{- end }}
-        {{- end }}
-        {{- end }}
+        {{- include "jitsu.waitFor.initContainers" (list $ .Values.console) | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with (.Values.console.securityContext | default .Values.global.securityContext) }}

--- a/templates/event-log-init/job.yaml
+++ b/templates/event-log-init/job.yaml
@@ -31,23 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- with .Values.eventLogInit.waitFor }}
-        {{- range . }}
-        {{- if (fromYaml (tpl (.enabled | default "true") $ )) }}
-        - name: {{ printf "wait-for-%s" .name | quote }}
-          image: {{ include "jitsu.waitFor.image" $ }}
-          {{- with ($.Values.eventLogInit.securityContext | default $.Values.global.securityContext) }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          command: ["kubectl", "wait"]
-          args:
-            - {{ tpl .for $ | printf "--for=%s" | quote }}
-            - {{ default "300s" .timeout | printf "--timeout=%s" | quote }}
-            - {{ tpl .resource $ | quote }}
-        {{- end }}
-        {{- end }}
-        {{- end }}
+        {{- include "jitsu.waitFor.initContainers" (list $ .Values.eventLogInit) | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with (.Values.eventLogInit.securityContext | default .Values.global.securityContext) }}

--- a/templates/ingest/deployment.yaml
+++ b/templates/ingest/deployment.yaml
@@ -38,23 +38,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- with .Values.ingest.waitFor }}
-        {{- range . }}
-        {{- if (fromYaml (tpl (.enabled | default "true") $ )) }}
-        - name: {{ printf "wait-for-%s" .name | quote }}
-          image: {{ include "jitsu.waitFor.image" $ }}
-          {{- with ($.Values.ingest.securityContext | default $.Values.global.securityContext) }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          command: ["kubectl", "wait"]
-          args:
-            - {{ tpl .for $ | printf "--for=%s" | quote }}
-            - {{ default "300s" .timeout | printf "--timeout=%s" | quote }}
-            - {{ tpl .resource $ | quote }}
-        {{- end }}
-        {{- end }}
-        {{- end }}
+        {{- include "jitsu.waitFor.initContainers" (list $ .Values.ingest) | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with (.Values.ingest.securityContext | default .Values.global.securityContext) }}

--- a/templates/migration/job.yaml
+++ b/templates/migration/job.yaml
@@ -31,23 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- with .Values.migration.waitFor }}
-        {{- range . }}
-        {{- if (fromYaml (tpl (.enabled | default "true") $ )) }}
-        - name: {{ printf "wait-for-%s" .name | quote }}
-          image: {{ include "jitsu.waitFor.image" $ }}
-          {{- with ($.Values.migration.securityContext | default $.Values.global.securityContext) }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          command: ["kubectl", "wait"]
-          args:
-            - {{ tpl .for $ | printf "--for=%s" | quote }}
-            - {{ default "300s" .timeout | printf "--timeout=%s" | quote }}
-            - {{ tpl .resource $ | quote }}
-        {{- end }}
-        {{- end }}
-        {{- end }}
+        {{- include "jitsu.waitFor.initContainers" (list $ .Values.migration) | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with (.Values.migration.securityContext | default .Values.global.securityContext) }}

--- a/templates/rotor/deployment.yaml
+++ b/templates/rotor/deployment.yaml
@@ -38,23 +38,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- with .Values.rotor.waitFor }}
-        {{- range . }}
-        {{- if (fromYaml (tpl (.enabled | default "true") $ )) }}
-        - name: {{ printf "wait-for-%s" .name | quote }}
-          image: {{ include "jitsu.waitFor.image" $ }}
-          {{- with ($.Values.rotor.securityContext | default $.Values.global.securityContext) }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          command: ["kubectl", "wait"]
-          args:
-            - {{ tpl .for $ | printf "--for=%s" | quote }}
-            - {{ default "300s" .timeout | printf "--timeout=%s" | quote }}
-            - {{ tpl .resource $ | quote }}
-        {{- end }}
-        {{- end }}
-        {{- end }}
+        {{- include "jitsu.waitFor.initContainers" (list $ .Values.rotor) | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with (.Values.rotor.securityContext | default .Values.global.securityContext) }}

--- a/templates/syncctl/deployment.yaml
+++ b/templates/syncctl/deployment.yaml
@@ -38,23 +38,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- with .Values.syncctl.waitFor }}
-        {{- range . }}
-        {{- if (fromYaml (tpl (.enabled | default "true") $ )) }}
-        - name: {{ printf "wait-for-%s" .name | quote }}
-          image: {{ include "jitsu.waitFor.image" $ }}
-          {{- with ($.Values.syncctl.securityContext | default $.Values.global.securityContext) }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          command: ["kubectl", "wait"]
-          args:
-            - {{ tpl .for $ | printf "--for=%s" | quote }}
-            - {{ default "300s" .timeout | printf "--timeout=%s" | quote }}
-            - {{ tpl .resource $ | quote }}
-        {{- end }}
-        {{- end }}
-        {{- end }}
+        {{- include "jitsu.waitFor.initContainers" (list $ .Values.syncctl) | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with (.Values.syncctl.securityContext | default .Values.global.securityContext) }}

--- a/values.yaml
+++ b/values.yaml
@@ -489,7 +489,7 @@ bulker:
       resource: 'jobs.batch/{{ include "jitsu.fullname" . }}-migration-{{ include "jitsu.hash" . }}'
       for: condition=Complete=True
     - name: console
-      condition: '{{ .Values.console.enabled }}'
+      enabled: '{{ .Values.console.enabled }}'
       resource: 'deployments.apps/{{ include "jitsu.fullname" . }}-console'
       for: condition=Available=true
     - name: clickhouse
@@ -648,7 +648,7 @@ rotor:
       resource: 'jobs.batch/{{ include "jitsu.fullname" . }}-migration-{{ include "jitsu.hash" . }}'
       for: condition=Complete=True
     - name: console
-      condition: '{{ .Values.console.enabled }}'
+      enabled: '{{ .Values.console.enabled }}'
       resource: 'deployments.apps/{{ include "jitsu.fullname" . }}-console'
       for: condition=Available=true
     - name: bulker
@@ -822,7 +822,7 @@ ingest:
       resource: 'jobs.batch/{{ include "jitsu.fullname" . }}-migration-{{ include "jitsu.hash" . }}'
       for: condition=Complete=True
     - name: console
-      condition: '{{ .Values.console.enabled }}'
+      enabled: '{{ .Values.console.enabled }}'
       resource: 'deployments.apps/{{ include "jitsu.fullname" . }}-console'
       for: condition=Available=true
     - name: rotor
@@ -1048,7 +1048,7 @@ eventLogInit:
       resource: 'jobs.batch/{{ include "jitsu.fullname" . }}-token-generator-{{ include "jitsu.hash" . }}'
       for: condition=Complete=true
     - name: console
-      condition: '{{ .Values.console.enabled }}'
+      enabled: '{{ .Values.console.enabled }}'
       resource: 'deployments.apps/{{ include "jitsu.fullname" . }}-console'
       for: condition=Available=true
 


### PR DESCRIPTION
Fixes #87

Is this ideal? No, but Helm is pretty limited in this regard, and this
works with booleans. Just don't make initContainer conditions assuming
typical Helm boolean coercion.

Also adds a typical flake with a devShell that provides Helm.
