### PR TITLE
feat: support secret-based Kafka bootstrap servers and log format for bulker

### DIFF
--- a/scripts/token-generator.py
+++ b/scripts/token-generator.py
@@ -47,7 +47,7 @@ def getSecret(fullname):
     )
     if proc.returncode == 0:
         return json.loads(proc.stdout)
-    return None 
+    return None
 
 def updateSecret(secret):
     subprocess.run(
@@ -74,7 +74,7 @@ def generateTokenSet(service, globalHashSecret):
 
 def validateTokenSet(service, token, hashes, globalHashSecret):
     if service == "console":
-        prefix, token = token.split(":")[1]
+        prefix, token = token.split(":")
         if prefix != "service-admin-account":
             raise ValueError
     for hash in hashes.split(","):

--- a/templates/bulker/_helpers.tpl
+++ b/templates/bulker/_helpers.tpl
@@ -142,6 +142,16 @@ app.kubernetes.io/component: bulker
   value: {{ . | quote }}
 {{- end }}
 
+{{- with .logFormat }}
+- name: BULKER_LOG_FORMAT
+  value: {{ . | quote }}
+{{- end }}
+
+{{- if or .kafkaBootstrapServersFrom $.Values.config.kafkaBootstrapServersFrom }}
+- name: BULKER_KAFKA_BOOTSTRAP_SERVERS
+  valueFrom:
+    {{- toYaml (.kafkaBootstrapServersFrom | default $.Values.config.kafkaBootstrapServersFrom) | nindent 4 }}
+{{- else }}
 {{- if and (not .kafkaBootstrapServers) (not $.Values.config.kafkaBootstrapServers) $.Values.kafka.enabled }}
 - name: BULKER_KAFKA_BOOTSTRAP_SERVERS
   value: "{{ $.Release.Name }}-kafka:9092"
@@ -149,6 +159,7 @@ app.kubernetes.io/component: bulker
 {{- with (.kafkaBootstrapServers | default $.Values.config.kafkaBootstrapServers) }}
 - name: BULKER_KAFKA_BOOTSTRAP_SERVERS
   value: {{ . | quote }}
+{{- end }}
 {{- end }}
 
 {{- with (.kafkaSsl | default $.Values.config.kafkaSsl) }}

--- a/templates/ingest/_helpers.tpl
+++ b/templates/ingest/_helpers.tpl
@@ -160,6 +160,11 @@ app.kubernetes.io/component: ingest
   value: {{ . | quote }}
 {{- end }}
 
+{{- if or .kafkaBootstrapServersFrom $.Values.config.kafkaBootstrapServersFrom }}
+- name: INGEST_KAFKA_BOOTSTRAP_SERVERS
+  valueFrom:
+    {{- toYaml (.kafkaBootstrapServersFrom | default $.Values.config.kafkaBootstrapServersFrom) | nindent 4 }}
+{{- else }}
 {{- if and (not .kafkaBootstrapServers) (not $.Values.config.kafkaBootstrapServers) $.Values.kafka.enabled }}
 - name: INGEST_KAFKA_BOOTSTRAP_SERVERS
   value: "{{ $.Release.Name }}-kafka:9092"
@@ -167,6 +172,7 @@ app.kubernetes.io/component: ingest
 {{- with (.kafkaBootstrapServers | default $.Values.config.kafkaBootstrapServers) }}
 - name: INGEST_KAFKA_BOOTSTRAP_SERVERS
   value: {{ . | quote }}
+{{- end }}
 {{- end }}
 
 {{- with (.kafkaSsl | default $.Values.config.kafkaSsl) }}

--- a/templates/rotor/_helpers.tpl
+++ b/templates/rotor/_helpers.tpl
@@ -176,6 +176,11 @@ app.kubernetes.io/component: rotor
 {{- end }}
 {{- end }}
 
+{{- if or .kafkaBootstrapServersFrom $.Values.config.kafkaBootstrapServersFrom }}
+- name: KAFKA_BOOTSTRAP_SERVERS
+  valueFrom:
+    {{- toYaml (.kafkaBootstrapServersFrom | default $.Values.config.kafkaBootstrapServersFrom) | nindent 4 }}
+{{- else }}
 {{- if and (not .kafkaBootstrapServers) (not $.Values.config.kafkaBootstrapServers) $.Values.kafka.enabled }}
 - name: KAFKA_BOOTSTRAP_SERVERS
   value: {{ printf "%s-kafka:9092" $.Release.Name | quote }}
@@ -183,6 +188,7 @@ app.kubernetes.io/component: rotor
 {{- with (.kafkaBootstrapServers | default $.Values.config.kafkaBootstrapServers) }}
 - name: KAFKA_BOOTSTRAP_SERVERS
   value: {{ . | quote }}
+{{- end }}
 {{- end }}
 
 {{- with (.kafkaSsl | default $.Values.config.kafkaSsl) }}

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,7 @@ config:
   # Global Kafka configuration. Leave empty if using Kafka subchart.
   # List of hosts in the format of: host:port,...
   kafkaBootstrapServers: ""
+  # kafkaBootstrapServersFrom: {}
   # Enable/disable SSL
   kafkaSsl: ""
   # Dict or JSON string with SASL configuration. Leave empty to disable.
@@ -329,7 +330,6 @@ bulker:
     # UUID of bulker instance
     # https://github.com/jitsucom/bulker/blob/main/.docs/server-config.md#bulker_instance_id
     instanceId: ""
-    instanceIdFrom: {}
 
     # Leave empty to configure automatically.
     # https://github.com/jitsucom/bulker/blob/main/.docs/server-config.md#bulker_config_source
@@ -373,6 +373,7 @@ bulker:
     # Leave empty to automatically configure.
     # https://github.com/jitsucom/bulker/blob/main/.docs/server-config.md#bulker_kafka_bootstrap_servers
     kafkaBootstrapServers: ""
+    # kafkaBootstrapServersFrom: {}
 
     # https://github.com/jitsucom/bulker/blob/main/.docs/server-config.md#bulker_kafka_ssl
     kafkaSsl: "false"
@@ -436,6 +437,10 @@ bulker:
 
     # https://github.com/jitsucom/bulker/blob/main/.docs/server-config.md#connection-to-redis-optional
     eventsLogMaxSize: ""
+
+    # Log format. One of "text", "json".
+    # https://github.com/jitsucom/bulker/blob/c5548cf95c939f078f1a8faa48dbb2e299505789/jitsubase/appbase/app_base.go#L54-L55
+    # logFormat: "text"
   replicaCount: 1
   image:
     repository: jitsucom/bulker
@@ -562,6 +567,7 @@ rotor:
     # Leave empty to configure automatically if config.kafkaBootstrapServers is set or Kafka subchart is being used.
     # https://docs.jitsu.com/self-hosting/configuration#kafka_bootstrap_servers
     kafkaBootstrapServers: ""
+    # kafkaBootstrapServersFrom: {}
 
     # https://docs.jitsu.com/self-hosting/configuration#kafka_ssl
     kafkaSsl: "false"
@@ -716,6 +722,7 @@ ingest:
     # Leave empty to configure automatically when Kafka subchart is enabled or config.kafkaBootstrapServers is set.
     # https://docs.jitsu.com/self-hosting/configuration#ingest_kafka_bootstrap_servers
     kafkaBootstrapServers: ""
+    # kafkaBootstrapServersFrom: {}
 
     # https://docs.jitsu.com/self-hosting/configuration#ingest_kafka_ssl
     kafkaSsl: ""
@@ -1059,9 +1066,8 @@ serviceAccount:
   annotations: {}
   name: ""
 
+# initContainers waiting for conditions on other components
 waitFor:
-  # initContainers waiting for conditions on other components
-  enabled: true
   image:
     repository: alpine/k8s
     tag: ""

--- a/values.yaml
+++ b/values.yaml
@@ -20,7 +20,7 @@ config:
   # Global Kafka configuration. Leave empty if using Kafka subchart.
   # List of hosts in the format of: host:port,...
   kafkaBootstrapServers: ""
-  # kafkaBootstrapServersFrom: {}
+  kafkaBootstrapServersFrom: {}
   # Enable/disable SSL
   kafkaSsl: ""
   # Dict or JSON string with SASL configuration. Leave empty to disable.
@@ -373,7 +373,7 @@ bulker:
     # Leave empty to automatically configure.
     # https://github.com/jitsucom/bulker/blob/main/.docs/server-config.md#bulker_kafka_bootstrap_servers
     kafkaBootstrapServers: ""
-    # kafkaBootstrapServersFrom: {}
+    kafkaBootstrapServersFrom: {}
 
     # https://github.com/jitsucom/bulker/blob/main/.docs/server-config.md#bulker_kafka_ssl
     kafkaSsl: "false"
@@ -440,7 +440,7 @@ bulker:
 
     # Log format. One of "text", "json".
     # https://github.com/jitsucom/bulker/blob/c5548cf95c939f078f1a8faa48dbb2e299505789/jitsubase/appbase/app_base.go#L54-L55
-    # logFormat: "text"
+    logFormat: "text"
   replicaCount: 1
   image:
     repository: jitsucom/bulker
@@ -567,7 +567,7 @@ rotor:
     # Leave empty to configure automatically if config.kafkaBootstrapServers is set or Kafka subchart is being used.
     # https://docs.jitsu.com/self-hosting/configuration#kafka_bootstrap_servers
     kafkaBootstrapServers: ""
-    # kafkaBootstrapServersFrom: {}
+    kafkaBootstrapServersFrom: {}
 
     # https://docs.jitsu.com/self-hosting/configuration#kafka_ssl
     kafkaSsl: "false"
@@ -722,7 +722,7 @@ ingest:
     # Leave empty to configure automatically when Kafka subchart is enabled or config.kafkaBootstrapServers is set.
     # https://docs.jitsu.com/self-hosting/configuration#ingest_kafka_bootstrap_servers
     kafkaBootstrapServers: ""
-    # kafkaBootstrapServersFrom: {}
+    kafkaBootstrapServersFrom: {}
 
     # https://docs.jitsu.com/self-hosting/configuration#ingest_kafka_ssl
     kafkaSsl: ""


### PR DESCRIPTION
Hey 👋🏻 

### Description

I just started working with this chart and found a few points that could be improved along the way. So, decided to open this pull request.

**Main changes**

- feat: added support to `kafkaBootstrapServersFrom` for bulker/ingest/rotor
- feat: added support to declare a `logFormat` for bulker (similar to what is done for other components)
- fix: updated validation in the token generator script to avoid it recreating a secret for console every time it runs
- chore: removed unused properties from `values.yaml`
  - `bulker.config.instanceIdFrom` is not referenced anywhere
  - `waitFor.enabled`: this is controlled per component here: https://github.com/stafftastic/jitsu-chart/blob/12106d0ffded15c7c640889d3d60fb8087654fd2/templates/_helpers.tpl#L174

### Notes

Not sure if I'm missing something here. If so, please let me know. Thanks!
