### PR TITLE
fix(console): remove duplicate env vars

### DIFF
--- a/templates/console/_helpers.tpl
+++ b/templates/console/_helpers.tpl
@@ -321,17 +321,6 @@ app.kubernetes.io/component: console
 {{- end }}
 {{- end }}
 
-{{- if .clickhouseUrlFrom }}
-- name: CLICKHOUSE_URL
-  valueFrom:
-    {{- toYaml .clickhouseUrlFrom | nindent 4 }}
-{{- else }}
-{{- with .clickhouseUrl }}
-- name: CLICKHOUSE_URL
-  value: {{ . | quote }}
-{{- end }}
-{{- end }}
-
 {{- with .logFormat }}
 - name: LOG_FORMAT
   value: {{ . | quote }}

--- a/templates/console/_helpers.tpl
+++ b/templates/console/_helpers.tpl
@@ -332,28 +332,6 @@ app.kubernetes.io/component: console
 {{- end }}
 {{- end }}
 
-{{- if .clickhouseUsernameFrom }}
-- name: CLICKHOUSE_USERNAME
-  valueFrom:
-    {{- toYaml .clickhouseUsernameFrom | nindent 4 }}
-{{- else }}
-{{- with .clickhouseUsername }}
-- name: CLICKHOUSE_USERNAME
-  value: {{ . | quote }}
-{{- end }}
-{{- end }}
-
-{{- if .clickhousePasswordFrom }}
-- name: CLICKHOUSE_PASSWORD
-  valueFrom:
-    {{- toYaml .clickhousePasswordFrom | nindent 4 }}
-{{- else }}
-{{- with .clickhousePassword }}
-- name: CLICKHOUSE_PASSWORD
-  value: {{ . | quote }}
-{{- end }}
-{{- end }}
-
 {{- with .logFormat }}
 - name: LOG_FORMAT
   value: {{ . | quote }}


### PR DESCRIPTION
Fixes #92

---

As I understand, the following block should already cover these cases:

https://github.com/stafftastic/jitsu-chart/blob/f0b0c3e94f35a79d61f12c05d5d9a9f325a130f1/templates/console/_helpers.tpl#L64-L80